### PR TITLE
:sparkles: (minor) Add version command to adapter firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,12 @@ jobs:
         run: conan hal setup
 
       - name: 📦 Build adapter firmware for target "stm32f103c8"
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: conan build adapter-firmware -pr:a hal/tc/gcc -pr:h hal/mcu/stm32f103c8
+
+      - name: 📦 Build adapter firmware for target "stm32f103c8"
+        if: startsWith(github.ref, 'refs/tags/')
+        run: conan build adapter-firmware -pr:a hal/tc/gcc -pr:h hal/mcu/stm32f103c8 --version=${{ github.event.release.tag_name }}
 
       - name: 🚀 Push Binaries to Release
         uses: softprops/action-gh-release@v2

--- a/adapter-firmware/CMakeLists.txt
+++ b/adapter-firmware/CMakeLists.txt
@@ -28,6 +28,8 @@ if("$ENV{LIBHAL_PLATFORM}" STREQUAL "")
         "this project.")
 endif()
 
+message(WARNING "Version is: \"${E10_ADAPTER_VERSION}\"")
+
 find_package(libhal-$ENV{LIBHAL_PLATFORM_LIBRARY} REQUIRED CONFIG)
 find_package(libhal-util REQUIRED CONFIG)
 
@@ -41,6 +43,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC include .)
 target_link_libraries(${PROJECT_NAME} PRIVATE
     libhal::$ENV{LIBHAL_PLATFORM_LIBRARY}
     libhal::util)
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+    E10_ADAPTER_VERSION="${E10_ADAPTER_VERSION}")
 
 libhal_post_build(${PROJECT_NAME})
 libhal_disassemble(${PROJECT_NAME})

--- a/adapter-firmware/conanfile.py
+++ b/adapter-firmware/conanfile.py
@@ -12,15 +12,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
 
 required_conan_version = ">=2.2.2"
 
 
 class app(ConanFile):
-    python_requires = "libhal-bootstrap/[>=4.3.0 <5]"
-    python_requires_extend = "libhal-bootstrap.app"
+    settings = "compiler", "build_type", "os", "arch"
+    options = {
+        "platform": ["ANY"],
+    }
+    default_options = {
+        "platform": "unspecified",
+    }
+
+    def set_version(self):
+        # Use latest if not specified via command line
+        if not self.version:
+            self.version = "latest"
 
     def requirements(self):
-        bootstrap = self.python_requires["libhal-bootstrap"]
-        bootstrap.module.add_demo_requirements(self)
+        self.requires("libhal-util/[^5.4.0]")
+        ARCHITECTURE = str(self.settings.arch)
+        if ARCHITECTURE.startswith("cortex-m"):
+            self.output.warning(
+                "libhal-arm-mcu usable platform detected...")
+            self.requires("libhal-arm-mcu/[^1.0.0]")
+        else:
+            self.output.warning("No platform library added...")
+
+    def layout(self):
+        BUILD_PATH = Path("build") / str(self.options.platform)
+        cmake_layout(self, build_folder=BUILD_PATH)
+
+    def build_requirements(self):
+        self.tool_requires("ninja/[^1.0.0]")
+        self.tool_requires("cmake/[^4.0.0]")
+        self.tool_requires("libhal-cmake-util/[^4.3.3]")
+
+    def generate(self):
+        virt = VirtualBuildEnv(self)
+        virt.generate()
+
+        cmake = CMakeDeps(self)
+        cmake.generate()
+
+        tc = CMakeToolchain(self)
+        tc.generator = "Ninja"
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.configure(variables={"E10_ADAPTER_VERSION": str(self.version)})
+        cmake.build()

--- a/adapter-firmware/src/main.cpp
+++ b/adapter-firmware/src/main.cpp
@@ -102,56 +102,68 @@ void application()
     transceiver_direction->level(true);  // send mode
 
     // process data
-    if (read_bytes[0] == 'l') {  // low freq request
-      // set frequency to low
-      frequency_select->level(false);
-      auto lf_results = get_strongest_signal(false,
-                                             *counter_reset,
-                                             *accumulator_reset,
-                                             *intensity,
-                                             *device_clock,
-                                             *console);
-
-      hal::write(*rs485_transceiver, lf_results, hal::never_timeout());
-      // delay some time to allow bytes to send
-      hal::delay(*device_clock, 2ms);
-
-    } else if (read_bytes[0] == 'h') {  // hi freq request
-      // set frequency to high
-      frequency_select->level(true);
-      auto hf_results = get_strongest_signal(true,
-                                             *counter_reset,
-                                             *accumulator_reset,
-                                             *intensity,
-                                             *device_clock,
-                                             *console);
-      hal::write(*rs485_transceiver, hf_results, hal::never_timeout());
-      // delay some time to allow bytes to send
-      hal::delay(*device_clock, 2ms);
-
-    } else if (read_bytes[0] == 'c') {  // cam request
-      std::array<hal::byte, 9> cam_data{ 0x00, 0x00, 0x00, 0x00, 0x00,
-                                         0x00, 0x00, 0x00, 0x00 };
-      try {
-        if (camera_connected) {
-          cam_data = get_camera_data(all_data_buffer, *i2c, *console);
-        } else {
-          hal::print<32>(*console, "Reconnecting Camera\n");
-          camera_connected =
-            camera_init(all_data_buffer, *i2c, *console, *device_clock);
-          cam_data = get_camera_data(all_data_buffer, *i2c, *console);
-        }
-      } catch (...) {
-        camera_connected = false;
-        hal::print<32>(*console, "Camera not connected...\n");
+    switch (read_bytes[0]) {
+      case 'v': {  // Version
+        // Version: 1.0.0
+        hal::write(*rs485_transceiver,
+                   std::to_array<u8>({ 1, 1, 0 }),
+                   hal::never_timeout());
+        break;
       }
-      // send camera data to vex
-      hal::write(*rs485_transceiver, cam_data, hal::never_timeout());
-      // delay some time to allow bytes to send
-      hal::delay(*device_clock, 10ms);
-    } else {
-      hal::print<32>(*console, "unkown read 0x%02X \n", read_bytes[0]);
+      case 'l': {
+        // set frequency to low
+        frequency_select->level(false);
+        auto lf_results = get_strongest_signal(false,
+                                               *counter_reset,
+                                               *accumulator_reset,
+                                               *intensity,
+                                               *device_clock,
+                                               *console);
+
+        hal::write(*rs485_transceiver, lf_results, hal::never_timeout());
+        break;
+      }
+      case 'h': {
+        // set frequency to high
+        frequency_select->level(true);
+        auto hf_results = get_strongest_signal(true,
+                                               *counter_reset,
+                                               *accumulator_reset,
+                                               *intensity,
+                                               *device_clock,
+                                               *console);
+        hal::write(*rs485_transceiver, hf_results, hal::never_timeout());
+        break;
+      }
+      case 'c': {
+        std::array<hal::byte, 9> cam_data{ 0x00, 0x00, 0x00, 0x00, 0x00,
+                                           0x00, 0x00, 0x00, 0x00 };
+        try {
+          if (camera_connected) {
+            cam_data = get_camera_data(all_data_buffer, *i2c, *console);
+          } else {
+            hal::print<32>(*console, "Reconnecting Camera\n");
+            camera_connected =
+              camera_init(all_data_buffer, *i2c, *console, *device_clock);
+            cam_data = get_camera_data(all_data_buffer, *i2c, *console);
+          }
+        } catch (...) {
+          camera_connected = false;
+          hal::print<32>(*console, "Camera not connected...\n");
+        }
+        // send camera data to vex
+        hal::write(*rs485_transceiver, cam_data, hal::never_timeout());
+      }
+      default:
+        hal::print<32>(*console, "unkown read 0x%02X \n", read_bytes[0]);
+        break;
     }
+  }
+  if (read_bytes[0] == 'l') {  // low freq request
+
+  } else if (read_bytes[0] == 'h') {  // hi freq request
+
+  } else if (read_bytes[0] == 'c') {  // cam request
   }
 }
 

--- a/adapter-firmware/src/main.cpp
+++ b/adapter-firmware/src/main.cpp
@@ -71,10 +71,16 @@ int main()
   application();
 }
 
+#if not defined(E10_ADAPTER_VERSION)
+#define E10_ADAPTER_VERSION "undef"
+#endif
+
+constexpr std::string_view version = E10_ADAPTER_VERSION;
+
 void application()
 {
   using namespace std::chrono_literals;
-  std::array<hal::byte, 256> all_data_buffer;
+  std::array<hal::byte, 256> all_data_buffer{};
   auto console = resources::console();
   auto rs485_transceiver = resources::rs485_transceiver();
   auto device_clock = resources::clock();
@@ -104,21 +110,18 @@ void application()
     // process data
     switch (read_bytes[0]) {
       case 'v': {  // Version
-        // Version: 1.0.0
-        hal::write(*rs485_transceiver,
-                   std::to_array<u8>({ 1, 1, 0 }),
-                   hal::never_timeout());
+        hal::write(*rs485_transceiver, version, hal::never_timeout());
         break;
       }
       case 'l': {
         // set frequency to low
         frequency_select->level(false);
-        auto lf_results = get_strongest_signal(false,
-                                               *counter_reset,
-                                               *accumulator_reset,
-                                               *intensity,
-                                               *device_clock,
-                                               *console);
+        auto const lf_results = get_strongest_signal(false,
+                                                     *counter_reset,
+                                                     *accumulator_reset,
+                                                     *intensity,
+                                                     *device_clock,
+                                                     *console);
 
         hal::write(*rs485_transceiver, lf_results, hal::never_timeout());
         break;
@@ -126,12 +129,12 @@ void application()
       case 'h': {
         // set frequency to high
         frequency_select->level(true);
-        auto hf_results = get_strongest_signal(true,
-                                               *counter_reset,
-                                               *accumulator_reset,
-                                               *intensity,
-                                               *device_clock,
-                                               *console);
+        auto const hf_results = get_strongest_signal(true,
+                                                     *counter_reset,
+                                                     *accumulator_reset,
+                                                     *intensity,
+                                                     *device_clock,
+                                                     *console);
         hal::write(*rs485_transceiver, hf_results, hal::never_timeout());
         break;
       }
@@ -155,15 +158,9 @@ void application()
         hal::write(*rs485_transceiver, cam_data, hal::never_timeout());
       }
       default:
-        hal::print<32>(*console, "unkown read 0x%02X \n", read_bytes[0]);
+        hal::print<32>(*console, "Unknown read 0x%02X \n", read_bytes[0]);
         break;
     }
-  }
-  if (read_bytes[0] == 'l') {  // low freq request
-
-  } else if (read_bytes[0] == 'h') {  // hi freq request
-
-  } else if (read_bytes[0] == 'c') {  // cam request
   }
 }
 
@@ -268,7 +265,7 @@ void flush_buffer(hal::i2c& p_i2c, hal::serial& p_console)
 
   while (!empty) {
     std::array<hal::byte, 4> data = hal::read<4>(p_i2c, camera_address);
-    // pre emptively set empty to true, if 4 empty bytes in a row are found,
+    // preemptively set empty to true, if 4 empty bytes in a row are found,
     // buffer is likely empty
     empty = true;
     hal::print(p_console, "Buffer Flush: ");
@@ -299,7 +296,7 @@ std::span<hal::byte> read_response_data(std::span<hal::byte> p_all_data_buffer,
   hal::byte algo;
 
   // error bytes to be sent in case of error, last byte is a variable to
-  // describe what error occured
+  // describe what error occurred
   // 0x01 = header1 mismatch
   // 0x02 = header2 mismatch
   std::span<hal::byte> error_bytes = p_all_data_buffer.subspan(0, 3);


### PR DESCRIPTION
Extracts version from git tags in the CI/CD workflow and pipes it
through the conan build system to embed in the firmware binary. Adds
a 'v' command that reports the firmware version when queried.

Changes:
- Extract version from git tags in GitHub workflow
- Pass version through conan and CMake to firmware
- Add version string definition in main.cpp
- Add new 'v' command case to return version
- Refactor conanfile.py to use explicit CMake setup instead of 
  libhal-bootstrap python_requires
- Convert command dispatcher from if-else-if to switch statement
