### PR TITLE
:zap: (patch) Move to LLVM for release binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,11 @@ jobs:
 
       - name: 📦 Build adapter firmware for target "stm32f103c8"
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: conan build adapter-firmware -pr:a hal/tc/gcc -pr:h hal/mcu/stm32f103c8
+        run: conan build adapter-firmware -pr:a hal/tc/llvm -pr:h hal/mcu/stm32f103c8
 
       - name: 📦 Build adapter firmware for target "stm32f103c8"
         if: startsWith(github.ref, 'refs/tags/')
-        run: conan build adapter-firmware -pr:a hal/tc/gcc -pr:h hal/mcu/stm32f103c8 --version=${{ github.event.release.tag_name }}
+        run: conan build adapter-firmware -pr:a hal/tc/llvm -pr:h hal/mcu/stm32f103c8 --version=${{ github.event.release.tag_name }}
 
       - name: 🚀 Push Binaries to Release
         uses: softprops/action-gh-release@v2

--- a/adapter-firmware/src/main.cpp
+++ b/adapter-firmware/src/main.cpp
@@ -183,7 +183,7 @@ void application()
         break;
     }
 
-    // Wait before setting the transceiver into read mode
+    // Wait before setting changing moving transceiver into read mode
     hal::delay(*device_clock, 100us);
   }
 }


### PR DESCRIPTION
GCC 14.2 seems to be 4kB larger than LLVM 20. Probably due to LTO being disabled in GCC.